### PR TITLE
Adjust layouts to meet max cpu limit

### DIFF
--- a/year2_cases/input_yaml/Day1/jedi_3dvar_fv3_2024022400.yaml
+++ b/year2_cases/input_yaml/Day1/jedi_3dvar_fv3_2024022400.yaml
@@ -11,7 +11,7 @@ cost function:
       field table filename: ./fv3jedi/field_table
     akbk: ./fv3jedi/akbk.nc4
     layout:
-    - 4
+    - 2
     - 4
     npx: 97
     npy: 97
@@ -103,7 +103,7 @@ cost function:
             gsi akbk: ./fv3jedi/akbk.nc4
             gsi error covariance file: ./berror/gsi-coeffs-gfs-global.nc
             gsi berror namelist file: ./berror/gfs_gsi_global.nml
-            processor layout x direction: 12
+            processor layout x direction: 6
             processor layout y direction: 8
             debugging mode: false
         saber outer blocks:
@@ -2565,7 +2565,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2582,7 +2582,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2631,7 +2631,7 @@ final:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 97
       npy: 97

--- a/year2_cases/input_yaml/Day1/jedi_3dvar_fv3inc_2024022400.yaml
+++ b/year2_cases/input_yaml/Day1/jedi_3dvar_fv3inc_2024022400.yaml
@@ -57,7 +57,7 @@ background geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -68,7 +68,7 @@ jedi increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -79,7 +79,7 @@ fv3 increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97

--- a/year2_cases/input_yaml/Day2/exp_hyb_weight/jedi_3dvar_fv3_2024022400.yaml
+++ b/year2_cases/input_yaml/Day2/exp_hyb_weight/jedi_3dvar_fv3_2024022400.yaml
@@ -11,7 +11,7 @@ cost function:
       field table filename: ./fv3jedi/field_table
     akbk: ./fv3jedi/akbk.nc4
     layout:
-    - 4
+    - 2
     - 4
     npx: 97
     npy: 97
@@ -103,7 +103,7 @@ cost function:
             gsi akbk: ./fv3jedi/akbk.nc4
             gsi error covariance file: ./berror/gsi-coeffs-gfs-global.nc
             gsi berror namelist file: ./berror/gfs_gsi_global.nml
-            processor layout x direction: 12
+            processor layout x direction: 6
             processor layout y direction: 8
             debugging mode: false
         saber outer blocks:
@@ -2573,7 +2573,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2590,7 +2590,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2639,7 +2639,7 @@ final:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 97
       npy: 97

--- a/year2_cases/input_yaml/Day2/exp_hyb_weight/jedi_3dvar_fv3inc_2024022400.yaml
+++ b/year2_cases/input_yaml/Day2/exp_hyb_weight/jedi_3dvar_fv3inc_2024022400.yaml
@@ -57,7 +57,7 @@ background geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -68,7 +68,7 @@ jedi increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -79,7 +79,7 @@ fv3 increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97

--- a/year2_cases/input_yaml/Day2/exp_nicas_scale/jedi_3dvar_fv3_2024022400.yaml
+++ b/year2_cases/input_yaml/Day2/exp_nicas_scale/jedi_3dvar_fv3_2024022400.yaml
@@ -11,7 +11,7 @@ cost function:
       field table filename: ./fv3jedi/field_table
     akbk: ./fv3jedi/akbk.nc4
     layout:
-    - 4
+    - 2
     - 4
     npx: 97
     npy: 97
@@ -103,7 +103,7 @@ cost function:
             gsi akbk: ./fv3jedi/akbk.nc4
             gsi error covariance file: ./berror/gsi-coeffs-gfs-global.nc
             gsi berror namelist file: ./berror/gfs_gsi_global.nml
-            processor layout x direction: 12
+            processor layout x direction: 6
             processor layout y direction: 8
             debugging mode: false
         saber outer blocks:
@@ -2568,7 +2568,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2585,7 +2585,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2634,7 +2634,7 @@ final:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 97
       npy: 97

--- a/year2_cases/input_yaml/Day2/exp_nicas_scale/jedi_3dvar_fv3inc_2024022400.yaml
+++ b/year2_cases/input_yaml/Day2/exp_nicas_scale/jedi_3dvar_fv3inc_2024022400.yaml
@@ -57,7 +57,7 @@ background geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -68,7 +68,7 @@ jedi increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -79,7 +79,7 @@ fv3 increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97

--- a/year2_cases/input_yaml/Day3/exp_atm_thinning/jedi_3dvar_fv3_2024022400.yaml
+++ b/year2_cases/input_yaml/Day3/exp_atm_thinning/jedi_3dvar_fv3_2024022400.yaml
@@ -11,7 +11,7 @@ cost function:
       field table filename: ./fv3jedi/field_table
     akbk: ./fv3jedi/akbk.nc4
     layout:
-    - 4
+    - 2
     - 4
     npx: 97
     npy: 97
@@ -103,7 +103,7 @@ cost function:
             gsi akbk: ./fv3jedi/akbk.nc4
             gsi error covariance file: ./berror/gsi-coeffs-gfs-global.nc
             gsi berror namelist file: ./berror/gfs_gsi_global.nml
-            processor layout x direction: 12
+            processor layout x direction: 6
             processor layout y direction: 8
             debugging mode: false
         saber outer blocks:
@@ -2569,7 +2569,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2586,7 +2586,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2635,7 +2635,7 @@ final:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 97
       npy: 97

--- a/year2_cases/input_yaml/Day3/exp_atm_thinning/jedi_3dvar_fv3inc_2024022400.yaml
+++ b/year2_cases/input_yaml/Day3/exp_atm_thinning/jedi_3dvar_fv3inc_2024022400.yaml
@@ -57,7 +57,7 @@ background geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -68,7 +68,7 @@ jedi increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -79,7 +79,7 @@ fv3 increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97

--- a/year2_cases/input_yaml/Day3/exp_atms_err/jedi_3dvar_fv3_2024022400.yaml
+++ b/year2_cases/input_yaml/Day3/exp_atms_err/jedi_3dvar_fv3_2024022400.yaml
@@ -11,7 +11,7 @@ cost function:
       field table filename: ./fv3jedi/field_table
     akbk: ./fv3jedi/akbk.nc4
     layout:
-    - 4
+    - 2
     - 4
     npx: 97
     npy: 97
@@ -103,7 +103,7 @@ cost function:
             gsi akbk: ./fv3jedi/akbk.nc4
             gsi error covariance file: ./berror/gsi-coeffs-gfs-global.nc
             gsi berror namelist file: ./berror/gfs_gsi_global.nml
-            processor layout x direction: 12
+            processor layout x direction: 6
             processor layout y direction: 8
             debugging mode: false
         saber outer blocks:
@@ -2612,7 +2612,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2629,7 +2629,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -2678,7 +2678,7 @@ final:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 97
       npy: 97

--- a/year2_cases/input_yaml/Day3/exp_atms_err/jedi_3dvar_fv3inc_2024022400.yaml
+++ b/year2_cases/input_yaml/Day3/exp_atms_err/jedi_3dvar_fv3inc_2024022400.yaml
@@ -57,7 +57,7 @@ background geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -68,7 +68,7 @@ jedi increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -79,7 +79,7 @@ fv3 increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97

--- a/year2_cases/input_yaml/Day3/exp_no_atms/jedi_3dvar_fv3_2024022400.yaml
+++ b/year2_cases/input_yaml/Day3/exp_no_atms/jedi_3dvar_fv3_2024022400.yaml
@@ -11,7 +11,7 @@ cost function:
       field table filename: ./fv3jedi/field_table
     akbk: ./fv3jedi/akbk.nc4
     layout:
-    - 4
+    - 2
     - 4
     npx: 97
     npy: 97
@@ -103,7 +103,7 @@ cost function:
             gsi akbk: ./fv3jedi/akbk.nc4
             gsi error covariance file: ./berror/gsi-coeffs-gfs-global.nc
             gsi berror namelist file: ./berror/gfs_gsi_global.nml
-            processor layout x direction: 12
+            processor layout x direction: 6
             processor layout y direction: 8
             debugging mode: false
         saber outer blocks:
@@ -1782,7 +1782,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -1799,7 +1799,7 @@ variational:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 49
       npy: 49
@@ -1848,7 +1848,7 @@ final:
         field table filename: ./fv3jedi/field_table
       akbk: ./fv3jedi/akbk.nc4
       layout:
-      - 4
+      - 2
       - 4
       npx: 97
       npy: 97

--- a/year2_cases/input_yaml/Day3/exp_no_atms/jedi_3dvar_fv3inc_2024022400.yaml
+++ b/year2_cases/input_yaml/Day3/exp_no_atms/jedi_3dvar_fv3inc_2024022400.yaml
@@ -57,7 +57,7 @@ background geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -68,7 +68,7 @@ jedi increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97
@@ -79,7 +79,7 @@ fv3 increment geometry:
     field table filename: ./fv3jedi/field_table
   akbk: ./fv3jedi/akbk.nc4
   layout:
-  - 4
+  - 2
   - 4
   npx: 97
   npy: 97

--- a/year2_cases/run_3dvar_hercules.sh
+++ b/year2_cases/run_3dvar_hercules.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -l
-#SBATCH --account=epic
+#SBATCH --account=epic-explorer
 #SBATCH --job-name=fv3jedi
 #SBATCH --output=log.cadre26.%j
 #SBATCH --partition=hercules-2
-#SBATCH --qos=batch
+#SBATCH --qos=cadre
 #SBATCH --time=00:20:00
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=48

--- a/year2_cases/run_3dvar_hercules.sh
+++ b/year2_cases/run_3dvar_hercules.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -l
-#SBATCH --account=epic-explorer
+#SBATCH --account=epic
 #SBATCH --job-name=fv3jedi
 #SBATCH --output=log.cadre26.%j
-#SBATCH --partition=hercules
+#SBATCH --partition=hercules-2
 #SBATCH --qos=batch
 #SBATCH --time=00:20:00
-#SBATCH --nodes=2
+#SBATCH --nodes=1
 #SBATCH --ntasks-per-node=48
 #SBATCH --mem=128G
 ###SBATCH --exclusive
@@ -54,7 +54,7 @@ module list
 date
 pgm="fv3jedi_var.x"
 jedi_yaml="jedi_3dvar_fv3_2024022400.yaml"
-srun -n 96 ${JEDI_BIN_PATH}/$pgm ${jedi_yaml} >>OUTPUT.fv3jedi 2>errfile_fv3jedi
+srun -n 48 ${JEDI_BIN_PATH}/$pgm ${jedi_yaml} >>OUTPUT.fv3jedi 2>errfile_fv3jedi
 export err=$?
 if [[ $err != 0 ]]; then
   echo "FATAL ERROR: fv3-jedi failed."
@@ -64,7 +64,7 @@ date
 # Run JEDI executable for increment
 pgm="gdas_fv3jedi_fv3inc.x"
 jedi_inc_yaml="jedi_3dvar_fv3inc_2024022400.yaml"
-srun -n 96 ${JEDI_BIN_PATH}/$pgm ${jedi_inc_yaml} >>OUTPUT.fv3inc 2>errfile_inc
+srun -n 48 ${JEDI_BIN_PATH}/$pgm ${jedi_inc_yaml} >>OUTPUT.fv3inc 2>errfile_inc
 export err=$?
 if [[ $err != 0 ]]; then
   echo "FATAL ERROR: fv3-jedi increment failed."


### PR DESCRIPTION
- Change layout from 4x4 to 2x4 to reduce the number of cpus from 96 to 48 (max. cpu limit = 90).
- Tested with "epic" account, "batch" qos (cadre qos doesn't work).
- Running (wall-clock) time:
   - Day1: ~11 min
   - Day2-1: ~11 min
   - Day2-2: ~11 min
   - Day3-1: ~ 9 min
   - Day3-2: ~ 11 min
   - Day3-3: ~ 7 min